### PR TITLE
Fix Pydantic v2 deprecation warning in json_adapter

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -210,7 +210,7 @@ def _get_structured_outputs_response_format(signature: SignatureMeta) -> type[py
     pydantic_model = pydantic.create_model(
         "DSPyProgramOutputs",
         **fields,
-        __config__=type("Config", (), {"extra": "forbid"}),
+        model_config={"extra": "forbid"},
     )
 
     # Generate the initial schema.


### PR DESCRIPTION
## Summary
This PR fixes a Pydantic v2 deprecation warning in the `json_adapter.py` file.

## Changes
- Replace deprecated `__config__` parameter with `model_config` in `pydantic.create_model()`
- This resolves the `PydanticDeprecatedSince20` warning about class-based config being deprecated

## Test plan
Ran `uv run pytest tests/predict` to verify tests still pass. The warning that appears during tests is from the `litellm` dependency, not from dspy code.